### PR TITLE
Add oauth connect step after first sign in

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -76,4 +76,12 @@ class ApplicationController < ActionController::Base
     end
   end
 
+  def after_sign_in_path_for(resource)
+    if resource.sign_in_count < 2
+      '/connect'
+    else
+      request.env['omniauth.origin'] || stored_location_for(resource) || root_path
+    end
+  end
+
 end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -197,6 +197,9 @@ class UsersController < ApplicationController
     active_filters.delete_if { |key, value| value.blank? }
   end
 
+  def connect
+  end
+
   private
 
   def user_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
 
   match '/users/:id/finish_signup' => 'users#finish_signup', via: [:get, :patch], :as => :finish_signup
 
+  get '/connect' => 'users#connect'
 
 
 end


### PR DESCRIPTION
Fixes #286 

Rather than having a two-step registration flow, users are directed to an oauth connect page after they confirm their email and sign in for the first time.